### PR TITLE
Fix for randomly Iterator's state 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
 ## [0.9.21] - 2024-06-27
 ### Changed
 - Add integer domains to few boolean functions to reduce timing of fun.super_image
+- Break equality for some datatype by changing DataType's is_subset_of during the Variant trait implementation.  
 
 ## [0.9.20] - 2024-06-20
 ### Added

--- a/src/data_type/function.rs
+++ b/src/data_type/function.rs
@@ -1478,10 +1478,10 @@ pub fn gt() -> impl Function {
 
 pub fn lt() -> impl Function {
     Polymorphic::default()
-    .with(PartitionnedMonotonic::bivariate(
-        (data_type::Integer::default(), data_type::Integer::default()),
-        |a, b| (a < b),
-    ))
+        .with(PartitionnedMonotonic::bivariate(
+            (data_type::Integer::default(), data_type::Integer::default()),
+            |a, b| (a < b),
+        ))
         .with(PartitionnedMonotonic::bivariate(
             (data_type::Float::default(), data_type::Float::default()),
             |a, b| (a < b),
@@ -1965,7 +1965,8 @@ pub fn extract_epoch() -> impl Function {
         .with(PartitionnedMonotonic::univariate(
             data_type::Date::default(),
             |a| {
-                (a.and_hms_opt(0,0,0).unwrap().and_utc().timestamp() as i64).clamp(<i64 as Bound>::min(), <i64 as Bound>::max())
+                (a.and_hms_opt(0, 0, 0).unwrap().and_utc().timestamp() as i64)
+                    .clamp(<i64 as Bound>::min(), <i64 as Bound>::max())
             },
         ))
         .with(PartitionnedMonotonic::univariate(
@@ -2837,7 +2838,7 @@ mod tests {
         println!("co_domain = {}", fun.co_domain());
 
         let set = DataType::from(Struct::from_data_types([
-            DataType::from(data_type::Integer::from_interval(1, 100000) ),
+            DataType::from(data_type::Integer::from_interval(1, 100000)),
             DataType::from(data_type::Integer::from_interval(1, 100000)),
         ]));
 
@@ -3411,7 +3412,6 @@ mod tests {
         );
         assert!(set.is_subset_of(&sum().domain()));
     }
-
 
     #[test]
     fn test_case() {

--- a/src/data_type/mod.rs
+++ b/src/data_type/mod.rs
@@ -2585,9 +2585,27 @@ impl Variant for DataType {
                         left.into_data_type(&right)
                             .map_or(false, |left| left.is_subset_of(&right))
                     }
-                    (DataType::Struct(s), DataType::Union(o)) => {
-                        let left = DataType::Struct(s.clone());
-                        let right = DataType::Union(o.clone());
+                    (DataType::Boolean(s), DataType::Float(o)) => {
+                        let left = DataType::Boolean(s.clone());
+                        let right = DataType::Float(o.clone());
+                        left.into_data_type(&right)
+                            .map_or(false, |left| left.is_subset_of(&right))
+                    }
+                    (DataType::Float(s), DataType::Boolean(o)) => {
+                        let left = DataType::Float(s.clone());
+                        let right = DataType::Boolean(o.clone());
+                        left.into_data_type(&right)
+                            .map_or(false, |left| left.is_subset_of(&right))
+                    }
+                    (DataType::Boolean(s), DataType::Integer(o)) => {
+                        let left = DataType::Boolean(s.clone());
+                        let right = DataType::Integer(o.clone());
+                        left.into_data_type(&right)
+                            .map_or(false, |left| left.is_subset_of(&right))
+                    }
+                    (DataType::Integer(s), DataType::Boolean(o)) => {
+                        let left = DataType::Integer(s.clone());
+                        let right = DataType::Boolean(o.clone());
                         left.into_data_type(&right)
                             .map_or(false, |left| left.is_subset_of(&right))
                     }
@@ -2603,15 +2621,9 @@ impl Variant for DataType {
                         left.into_data_type(&right)
                             .map_or(false, |left| left.is_subset_of(&right))
                     }
-                    (DataType::Boolean(s), DataType::Float(o)) => {
-                        let left = DataType::Boolean(s.clone());
-                        let right = DataType::Float(o.clone());
-                        left.into_data_type(&right)
-                            .map_or(false, |left| left.is_subset_of(&right))
-                    }
-                    (DataType::Float(s), DataType::Boolean(o)) => {
-                        let left = DataType::Float(s.clone());
-                        let right = DataType::Boolean(o.clone());
+                    (DataType::Struct(s), DataType::Union(o)) => {
+                        let left = DataType::Struct(s.clone());
+                        let right = DataType::Union(o.clone());
                         left.into_data_type(&right)
                             .map_or(false, |left| left.is_subset_of(&right))
                     }

--- a/src/data_type/mod.rs
+++ b/src/data_type/mod.rs
@@ -854,9 +854,7 @@ impl Struct {
         Struct::default().and(data_type)
     }
     /// Create from a slice of datatypes
-    pub fn from_data_types<T: Clone + fmt::Debug + Into<DataType>, A: AsRef<[T]>>(
-        data_types: A,
-    ) -> Struct {
+    pub fn from_data_types<T: Clone + Into<DataType>, A: AsRef<[T]>>(data_types: A) -> Struct {
         data_types
             .as_ref()
             .iter()
@@ -1008,9 +1006,7 @@ impl<S: Into<String>, T: Into<Arc<DataType>>> From<(S, T)> for Struct {
     }
 }
 
-impl<S: Clone + Into<String>, T: Clone + fmt::Debug + Into<Arc<DataType>>> From<&[(S, T)]>
-    for Struct
-{
+impl<S: Clone + Into<String>, T: Clone + Into<Arc<DataType>>> From<&[(S, T)]> for Struct {
     fn from(values: &[(S, T)]) -> Self {
         Struct::new(
             values
@@ -1346,9 +1342,7 @@ impl<S: Into<String>, T: Into<Arc<DataType>>> From<(S, T)> for Union {
     }
 }
 
-impl<S: Clone + Into<String>, T: Clone + fmt::Debug + Into<Arc<DataType>>> From<&[(S, T)]>
-    for Union
-{
+impl<S: Clone + Into<String>, T: Clone + Into<Arc<DataType>>> From<&[(S, T)]> for Union {
     fn from(values: &[(S, T)]) -> Self {
         Union::new(
             values
@@ -2975,7 +2969,7 @@ impl DataType {
 
     pub fn structured<
         S: Clone + Into<String>,
-        T: Clone + fmt::Debug + Into<Arc<DataType>>,
+        T: Clone + Into<Arc<DataType>>,
         F: AsRef<[(S, T)]>,
     >(
         fields: F,
@@ -3231,7 +3225,7 @@ impl<'a> Acceptor<'a> for DataType {
 // Visitors
 
 /// A Visitor for the type Expr
-pub trait Visitor<'a, T: Clone + fmt::Debug> {
+pub trait Visitor<'a, T: Clone> {
     // Composed types
     fn structured(&self, fields: Vec<(String, T)>) -> T;
     fn union(&self, fields: Vec<(String, T)>) -> T;
@@ -3244,7 +3238,7 @@ pub trait Visitor<'a, T: Clone + fmt::Debug> {
 }
 
 /// Implement a specific visitor to dispatch the dependencies more easily
-impl<'a, T: Clone + fmt::Debug, V: Visitor<'a, T>> visitor::Visitor<'a, DataType, T> for V {
+impl<'a, T: Clone, V: Visitor<'a, T>> visitor::Visitor<'a, DataType, T> for V {
     fn visit(&self, acceptor: &'a DataType, dependencies: visitor::Visited<'a, DataType, T>) -> T {
         match acceptor {
             DataType::Struct(s) => self.structured(

--- a/src/data_type/mod.rs
+++ b/src/data_type/mod.rs
@@ -3267,7 +3267,7 @@ impl<'a, T: Clone, V: Visitor<'a, T>> visitor::Visitor<'a, DataType, T> for V {
 }
 
 /// Implement a LiftOptionalVisitor
-pub struct FlattenOptionalVisitor;
+struct FlattenOptionalVisitor;
 
 impl<'a> Visitor<'a, (bool, DataType)> for FlattenOptionalVisitor {
     fn structured(&self, fields: Vec<(String, (bool, DataType))>) -> (bool, DataType) {
@@ -3323,8 +3323,7 @@ impl<'a> Visitor<'a, (bool, DataType)> for FlattenOptionalVisitor {
 impl DataType {
     /// Return a type with non-optional subtypes, it may be optional if one of the
     pub fn flatten_optional(&self) -> DataType {
-        let visitor = FlattenOptionalVisitor;
-        let (is_optional, flat) = self.accept(visitor);
+        let (is_optional, flat) = self.accept(FlattenOptionalVisitor);
         if is_optional {
             DataType::optional(flat)
         } else {
@@ -3481,7 +3480,6 @@ mod tests {
     #[test]
     fn test_inequalities() {
         let empty_interval = DataType::from(Intervals::<f64>::empty());
-        println!("{:?}", empty_interval);
         assert!(empty_interval <= DataType::text());
         println!(
             "{} <= {} is {}",

--- a/src/data_type/mod.rs
+++ b/src/data_type/mod.rs
@@ -3282,7 +3282,7 @@ impl DataType {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::convert::TryFrom;
+    use std::{convert::TryFrom, thread};
 
     #[test]
     fn test_null() {
@@ -4191,6 +4191,44 @@ mod tests {
         let fld: DataType = fl.clone().into();
         let l = il.into_data_type(&fld).unwrap();
         println!("l = {l}");
+    }
+
+    #[test]
+    fn test_list_bis() {
+        let il = DataType::List(List::from_data_type_size(
+            DataType::optional( DataType::optional(DataType::Any)),
+            Integer::from_interval(0, 9223372036854775807),
+        ));
+        println!("{:?}", il);
+        let fl = il.flatten_optional();
+        println!("fl = {fl}");
+        // println!("il <= fl = {}", il.is_subset_of(&fl));
+        // let fld: DataType = fl.clone().into();
+        // let l = il.into_data_type(&fld).unwrap();
+        // println!("l = {l}");
+    }
+
+    #[test]
+    fn test_concurrency_list() {
+        let il = DataType::List(List::from_data_type_size(
+            DataType::optional( DataType::optional(DataType::Any)),
+            Integer::from_interval(0, 9223372036854775807),
+        ));
+        let mut handles = vec![];
+
+        for _ in 0..1000 {
+            let i = il.clone();
+            let handle = thread::spawn(move || {
+                i.flatten_optional();
+            });
+            handles.push(handle);
+        }
+
+        for handle in handles {
+            handle.join().unwrap();
+        }
+        let fl = il.flatten_optional();
+        println!("fl = {fl}");
     }
 
     // Test round trip

--- a/src/data_type/mod.rs
+++ b/src/data_type/mod.rs
@@ -2634,7 +2634,7 @@ impl Variant for DataType {
                             .map_or(false, |left| left.is_subset_of(&right))
                     }
                     // let's try to be conservative. For any other combination return false
-                    (_, _) => false,
+                    _ => false,
                 }
             }
         )

--- a/src/visitor.rs
+++ b/src/visitor.rs
@@ -149,10 +149,10 @@ pub trait Acceptor<'a>: 'a + Sized + Debug + Eq + Hash {
         for (_a, s) in Iterator::new(visitor, self) {
             state = s
         }
-        if let State::Accept(output) = state {
-            output.clone()
-        } else {
-            panic!()
+        match state {
+            State::Push => {println!("ACCEPTOR: {:?}", self); panic!("FOUND A PUSH STATE. THIS SHOULD BE NOT POSSIBLE")},
+            State::Visit => {println!("ACCEPTOR: {:?}", self); panic!("FOUND A VISIT STATE. THIS SHOULD BE NOT POSSIBLE")},
+            State::Accept(output) => output.clone(),
         }
     }
 
@@ -324,4 +324,44 @@ mod tests {
         // assert_eq!(double_diamond.iter_with(DisplayVisitor).count(), 4);
         println!("The half diamond")
     }
+
+    // #[test]
+    // fn test_concurrent_state_mutation() {
+    //     let state = Arc::new(State::Push);
+    //     let mut handles = vec![];
+
+    //     for _ in 0..10 {
+    //         let state = Arc::clone(&state);
+    //         let handle = thread::spawn(move || {
+    //             let mut state = state.lock().unwrap();
+    //             match *state {
+    //                 State::Push => {
+    //                     println!("State is Push");
+    //                     *state = State::Visit;
+    //                 }
+    //                 State::Visit => {
+    //                     println!("State is Visit");
+    //                     *state = State::Accept("some_value".to_string());
+    //                 }
+    //                 State::Accept(ref val) => {
+    //                     println!("State is Accept with value: {}", val);
+    //                     *state = State::Push;
+    //                 }
+    //             }
+    //         });
+    //         handles.push(handle);
+    //     }
+
+    //     for handle in handles {
+    //         handle.join().unwrap();
+    //     }
+
+    //     // Assert the final state if needed
+    //     let final_state = state.lock().unwrap();
+    //     match *final_state {
+    //         State::Push => println!("Final state is Push"),
+    //         State::Visit => println!("Final state is Visit"),
+    //         State::Accept(ref val) => println!("Final state is Accept with value: {}", val),
+    //     }
+    // }
 }

--- a/src/visitor.rs
+++ b/src/visitor.rs
@@ -327,11 +327,11 @@ mod tests {
 
     // #[test]
     // fn test_concurrent_state_mutation() {
-    //     let state = Arc::new(State::Push);
+    //     let semi_diamond = build_semi_diamond();
+    //     let visitor = DisplayVisitor;
     //     let mut handles = vec![];
 
-    //     for _ in 0..10 {
-    //         let state = Arc::clone(&state);
+    //     for _ in 0..3 {
     //         let handle = thread::spawn(move || {
     //             let mut state = state.lock().unwrap();
     //             match *state {

--- a/src/visitor.rs
+++ b/src/visitor.rs
@@ -324,44 +324,4 @@ mod tests {
         // assert_eq!(double_diamond.iter_with(DisplayVisitor).count(), 4);
         println!("The half diamond")
     }
-
-    // #[test]
-    // fn test_concurrent_state_mutation() {
-    //     let semi_diamond = build_semi_diamond();
-    //     let visitor = DisplayVisitor;
-    //     let mut handles = vec![];
-
-    //     for _ in 0..3 {
-    //         let handle = thread::spawn(move || {
-    //             let mut state = state.lock().unwrap();
-    //             match *state {
-    //                 State::Push => {
-    //                     println!("State is Push");
-    //                     *state = State::Visit;
-    //                 }
-    //                 State::Visit => {
-    //                     println!("State is Visit");
-    //                     *state = State::Accept("some_value".to_string());
-    //                 }
-    //                 State::Accept(ref val) => {
-    //                     println!("State is Accept with value: {}", val);
-    //                     *state = State::Push;
-    //                 }
-    //             }
-    //         });
-    //         handles.push(handle);
-    //     }
-
-    //     for handle in handles {
-    //         handle.join().unwrap();
-    //     }
-
-    //     // Assert the final state if needed
-    //     let final_state = state.lock().unwrap();
-    //     match *final_state {
-    //         State::Push => println!("Final state is Push"),
-    //         State::Visit => println!("Final state is Visit"),
-    //         State::Accept(ref val) => println!("Final state is Accept with value: {}", val),
-    //     }
-    // }
 }

--- a/src/visitor.rs
+++ b/src/visitor.rs
@@ -150,8 +150,8 @@ pub trait Acceptor<'a>: 'a + Sized + Debug + Eq + Hash {
             state = s
         }
         match state {
-            State::Push => {println!("ACCEPTOR: {:?}", self); panic!("FOUND A PUSH STATE. THIS SHOULD BE NOT POSSIBLE")},
-            State::Visit => {println!("ACCEPTOR: {:?}", self); panic!("FOUND A VISIT STATE. THIS SHOULD BE NOT POSSIBLE")},
+            State::Push => panic!("Found a PUSH state for Acceptor: {:?}. This should not be possible at this point.", self),
+            State::Visit => panic!("Found a Visit state for Acceptor: {:?}. This should not be possible at this point.", self),
             State::Accept(output) => output.clone(),
         }
     }

--- a/src/visitor.rs
+++ b/src/visitor.rs
@@ -150,8 +150,8 @@ pub trait Acceptor<'a>: 'a + Sized + Debug + Eq + Hash {
             state = s
         }
         match state {
-            State::Push => panic!("Found a PUSH state for Acceptor: {:?}. This should not be possible at this point.", self),
-            State::Visit => panic!("Found a Visit state for Acceptor: {:?}. This should not be possible at this point.", self),
+            State::Push => panic!("Found a `Push` state for Acceptor: {:?}. This should not be possible at this point.", self),
+            State::Visit => panic!("Found a `Visit` state for Acceptor: {:?}. This should not be possible at this point.", self),
             State::Accept(output) => output.clone(),
         }
     }


### PR DESCRIPTION
In some cases, when visiting datatype with the FlattenOptionalVisitor, the code was panicking because the acceptor ended out in a not-allowed state and it was randomly happening. In the visitor module, in the Iterator's next method, `self.state.get(&dependency)` was sometimes finding a match when the self.state (which is a HashMap) did not have any dependency in it. 

This was partially caused by an inconsistent Eq implementation of the DataType, for instance it resulted that: List(Optional(Any)) is equal to Optional(Any). 

The problem was also appearing randomly because of the key hashing.
Quoting from HashMap get method: 

```
/// The key may be any borrowed form of the map's key type, but
/// [`Hash`] and [`Eq`] on the borrowed form *must* match those for
/// the key type.` 
```

I checked the hash (with a specific seed) of both dependency (not in the HashMap) and the datatype (in the HashMap) and they were different. Probably the method get hashes an object dependent of the argument and compares it with that of a similar object dependent on the actual key. Their hash was equal hashing using specific seeds, thus making the problem randomly appearing.

The aim of this MR is to break the equality for specific DataTypes pairs such as  List(Optional(Any)) and Optional(Any)