### PR TITLE
Adding attributes to data_type::Id

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.9.24] - 2024-11-27
+### Added
+- Add attributes to data_type::Id
+
 ## [0.9.24] - 2024-09-27
 ### Fixed
 - mssql and bigquery translator

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["Nicolas Grislain <ng@sarus.tech>"]
 name = "qrlew"
-version = "0.9.24"
+version = "0.9.25"
 edition = "2021"
 description = "Sarus Qrlew Engine"
 documentation = "https://docs.rs/qrlew"

--- a/src/data_type/mod.rs
+++ b/src/data_type/mod.rs
@@ -2172,8 +2172,16 @@ pub struct Id {
 }
 
 impl Id {
-    pub fn new(reference: Option<Arc<Id>>, unique: bool, attributes: BTreeMap<String, String> ) -> Id {
-        Id { reference, unique, attributes }
+    pub fn new(
+        reference: Option<Arc<Id>>,
+        unique: bool,
+        attributes: BTreeMap<String, String>,
+    ) -> Id {
+        Id {
+            reference,
+            unique,
+            attributes,
+        }
     }
 
     pub fn reference(&self) -> Option<&Id> {
@@ -2226,13 +2234,15 @@ impl Variant for Id {
         true
     }
 
-    // 
+    //
     fn super_union(&self, other: &Self) -> Result<Self> {
-        let attributes: BTreeMap<String, String> = self.attributes.iter()
+        let attributes: BTreeMap<String, String> = self
+            .attributes
+            .iter()
             .filter(|(key, value)| other.attributes.get(*key).map_or(false, |v| v == *value))
             .map(|(key, value)| (key.clone(), value.clone()))
             .collect();
-        
+
         Ok(Id::new(
             if self.reference == other.reference {
                 self.reference.clone()
@@ -2240,12 +2250,14 @@ impl Variant for Id {
                 None
             },
             false,
-            attributes
+            attributes,
         ))
     }
     // if attributes are equal
     fn super_intersection(&self, other: &Self) -> Result<Self> {
-        let attributes: BTreeMap<String, String> = self.attributes.iter()
+        let attributes: BTreeMap<String, String> = self
+            .attributes
+            .iter()
             .filter(|(key, value)| other.attributes.get(*key).map_or(false, |v| v == *value))
             .map(|(key, value)| (key.clone(), value.clone()))
             .collect();
@@ -2257,7 +2269,7 @@ impl Variant for Id {
                 None
             },
             self.unique && other.unique,
-            attributes
+            attributes,
         ))
     }
 
@@ -4590,7 +4602,11 @@ mod tests {
 
     #[test]
     fn test_id() {
-        let id = Id::new(None, false,  BTreeMap::from([("base".to_string(), "string".to_string())]));
+        let id = Id::new(
+            None,
+            false,
+            BTreeMap::from([("base".to_string(), "string".to_string())]),
+        );
         let left = DataType::Id(id.clone());
         let right = DataType::Id(id);
 
@@ -4602,26 +4618,44 @@ mod tests {
         println!("left ∩ left = {}", intersection);
         assert_eq!(intersection, left);
 
-        let left = DataType::Id(Id::new(None, false,  BTreeMap::from([("base".to_string(), "string".to_string())])));
-        let right = DataType::Id(Id::new(None, false,  BTreeMap::from([("base".to_string(), "int".to_string())])));
+        let left = DataType::Id(Id::new(
+            None,
+            false,
+            BTreeMap::from([("base".to_string(), "string".to_string())]),
+        ));
+        let right = DataType::Id(Id::new(
+            None,
+            false,
+            BTreeMap::from([("base".to_string(), "int".to_string())]),
+        ));
 
         let union = left.super_union(&right).unwrap();
         println!("left ∪ right = {}", union);
-        assert_eq!(union, DataType::Id(Id::new(None, false,  BTreeMap::new())));
+        assert_eq!(union, DataType::Id(Id::new(None, false, BTreeMap::new())));
 
         let intersection = left.super_intersection(&right).unwrap();
         println!("left ∩ right = {}", intersection);
-        assert_eq!(intersection, DataType::Id(Id::new(None, false,  BTreeMap::new())));
+        assert_eq!(
+            intersection,
+            DataType::Id(Id::new(None, false, BTreeMap::new()))
+        );
 
-        let left = DataType::Id(Id::new(None, false,  BTreeMap::from([("base".to_string(), "string".to_string())])));
-        let right = DataType::Id(Id::new(None, false,  BTreeMap::new()));
+        let left = DataType::Id(Id::new(
+            None,
+            false,
+            BTreeMap::from([("base".to_string(), "string".to_string())]),
+        ));
+        let right = DataType::Id(Id::new(None, false, BTreeMap::new()));
 
         let union = left.super_union(&right).unwrap();
         println!("left ∪ right = {}", union);
-        assert_eq!(union, DataType::Id(Id::new(None, false,  BTreeMap::new())));
+        assert_eq!(union, DataType::Id(Id::new(None, false, BTreeMap::new())));
 
         let intersection = left.super_intersection(&right).unwrap();
         println!("left ∩ right = {}", intersection);
-        assert_eq!(intersection, DataType::Id(Id::new(None, false,  BTreeMap::new())));
-    } 
+        assert_eq!(
+            intersection,
+            DataType::Id(Id::new(None, false, BTreeMap::new()))
+        );
+    }
 }


### PR DESCRIPTION
Attributes allow to store additional informations about the data type Id. Such information is lost very quickly when doing operations with ids and if it is not consistent among them.